### PR TITLE
Log grad norm before clipping

### DIFF
--- a/tests/test_mappo_update.py
+++ b/tests/test_mappo_update.py
@@ -113,3 +113,14 @@ def test_mappo_update_smoke(dummy_mappo):
     changed = any(not torch.allclose(wb, p)
                   for wb, p in zip(ws_before, dummy_mappo.policy.parameters()))
     assert changed, "Policy parameters should have been updated"
+
+def test_mappo_logs_grad_norm(dummy_mappo):
+    from unittest.mock import MagicMock
+
+    writer = MagicMock()
+    dummy_mappo.update(R_bootstrap_agents=None, dt=None,
+                       summary_writer=writer, global_step=1)
+
+    logged_tags = [c.args[0] for c in writer.add_scalar.call_args_list]
+    assert 'train/grad_norm_before_clip' in logged_tags
+    assert 'train/grad_norm_after_clip' in logged_tags


### PR DESCRIPTION
## Summary
- record grad norm before gradient clipping in MA2PPO_NC.update
- expose both pre-clip and post-clip gradient norms to TensorBoard
- test that the new metrics are logged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a315afa1c83339f54e82640503df6